### PR TITLE
Fix #59 - ci badge linking MOODLE_405_STABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# moodle-tool_forcedcache
+[![ci](https://github.com/catalyst/moodle-tool_forcedcache/actions/workflows/ci.yml/badge.svg?branch=MOODLE_405_STABLE)](https://github.com/catalyst/moodle-tool_forcedcache/actions/workflows/ci.yml?branch=MOODLE_405_STABLE)
 
-![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/catalyst/moodle-tool_forcedcache/ci.yml?label=ci&branch=MOODLE_405_STABLE)
+# moodle-tool_forcedcache
 
 * [What is this?](#what-is-this)
 * [Branches](#branches)


### PR DESCRIPTION
Fix #59 - ci badge linking MOODLE_405_STABLE