### PR TITLE
Set STATE_INITIALISING before loading config #68

### DIFF
--- a/classes/cache_factory.php
+++ b/classes/cache_factory.php
@@ -55,6 +55,10 @@ class tool_forcedcache_cache_factory extends cache_factory {
 
         if (!array_key_exists($class, $this->configs)) {
             // Create a new instance and call it to load it.
+            // As part of generating store instance config we test the initialisation of stores.
+            // Testing this may initialise DI, which will attempt to use cache for hookcallbacks.
+            // Setting the state to initialising will make it use ad-hoc cache for that request.
+            self::set_state(self::STATE_INITIALISING);
             $this->configs[$class] = new $class;
             $this->configs[$class]->load();
         }
@@ -67,7 +71,7 @@ class tool_forcedcache_cache_factory extends cache_factory {
             $this->set_state(self::STATE_STORES_DISABLED);
         } else {
             // We cannot directly set the state to enabled from disabled.
-            // So we instead start and finish an update.
+            // So we instead start and finish an update to set STATE_READY.
             $this->updating_started();
             $this->updating_finished();
         }


### PR DESCRIPTION
Resolves #68 

The root cause of this issue is essentially:

- Forcedcache initialises stores to test if the forced cache will work https://github.com/catalyst/moodle-tool_forcedcache/blob/MOODLE_405_STABLE/classes/cache_config.php#L239
- MDL-80815 added di::get(clock::class) to the initialisation of redis cache (main only)
- Calling that initialises di, which initialises hookcallbacks, which make use of caching
- When trying to create the definition it fails $instance->get_definition_by_id once which has debugging output we see
- Debugging output this early breaks session_set_save_handler(), which is fatal if you don't have an existing session.

The solution appears to be setting STATE_INITIALISING to use ad-hoc cache for that request. 

This is done in the core cache factory and should be relatively safe as $this->updating_finished() will set it to STATE_READY when finished. It was originally removed as part of #11 so we might want to double check the mentioned edge caches. 