### PR TITLE
Fix an intermittent bootstrap failure after cache purges

### DIFF
--- a/classes/cache_factory.php
+++ b/classes/cache_factory.php
@@ -53,14 +53,21 @@ class tool_forcedcache_cache_factory extends cache_factory {
             }
         }
 
+        $config = null;
+
         if (!array_key_exists($class, $this->configs)) {
             // Create a new instance and call it to load it.
             // As part of generating store instance config we test the initialisation of stores.
             // Testing this may initialise DI, which will attempt to use cache for hookcallbacks.
             // Setting the state to initialising will make it use ad-hoc cache for that request.
             self::set_state(self::STATE_INITIALISING);
-            $this->configs[$class] = new $class;
-            $this->configs[$class]->load();
+            $config = new $class();
+            $config->load();
+
+            // Re-register after load in case anything reset $this->configs.
+            $this->configs[$class] = $config;
+        } else {
+            $config = $this->configs[$class];
         }
 
         // We need the siteid in order to use the caches, but the siteid
@@ -77,7 +84,7 @@ class tool_forcedcache_cache_factory extends cache_factory {
         }
 
         // Return the instance.
-        return $this->configs[$class];
+        return $config;
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024093000;
-$plugin->release   = "2024093000";
+$plugin->version   = 2024093001;
+$plugin->release   = "2024093001";
 $plugin->requires  = 2024092700; // Requires 4.5.
 $plugin->component = 'tool_forcedcache'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2024093001;
 $plugin->release   = "2024093001";
-$plugin->requires  = 2024092700; // Requires 4.5.
+$plugin->requires  = 2024100700; // Requires 4.5.
 $plugin->component = 'tool_forcedcache'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
During `tool_forcedcache_cache_factory::create_config_instance()`, cache config loading can re-enter Moodle cache setup and reset the factory’s internal `$configs` array. The method then attempted to return `$this->configs[$class]`, which could emit an `undefined` array key warning and return `null`, leading to:
`Call to a member function get_definition_by_id() on null`

This patch keeps the newly created config instance in a local variable, loads it, then re-registers it in `$this->configs` after load completes. That makes the method robust if `$this->configs` is reset during config generation.

**Tested with:**
```bash
php admin/cli/purge_caches.php
php admin/cli/purge_caches.php
php admin/cli/purge_caches.php
```

It doesn't seem to be an issue in the `MOODLE_501_STABLE` branch