### PR TITLE
Add support for Moodle 500 and update versioning

### DIFF
--- a/classes/cache_administration_helper.php
+++ b/classes/cache_administration_helper.php
@@ -23,7 +23,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_forcedcache_cache_administration_helper extends core_cache\administration_helper {
-
     /**
      * Empty constructor so cache_helper::__construct isn't called.
      */
@@ -40,11 +39,11 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
      */
     public function get_store_instance_actions(string $name, array $storedetails): array {
         global $OUTPUT;
-        $actions = array();
+        $actions = [];
         if (has_capability('moodle/site:config', context_system::instance())) {
-            $baseurl = new moodle_url('/cache/admin.php', array('store' => $name, 'sesskey' => sesskey()));
+            $baseurl = new moodle_url('/cache/admin.php', ['store' => $name, 'sesskey' => sesskey()]);
             $actions[] = $OUTPUT->action_link(
-                new moodle_url($baseurl, array('action' => 'purgestore')),
+                new moodle_url($baseurl, ['action' => 'purgestore']),
                 get_string('purge', 'cache')
             );
         }
@@ -60,11 +59,11 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
      */
     public function get_definition_actions(context $context, array $definitionsummary): array {
         global $OUTPUT;
-        $actions = array();
+        $actions = [];
         if (has_capability('moodle/site:config', $context)) {
             $actions[] = $OUTPUT->action_link(
-                new moodle_url('/cache/admin.php', array('action' => 'purgedefinition',
-                    'definition' => $definitionsummary['id'], 'sesskey' => sesskey())),
+                new moodle_url('/cache/admin.php', ['action' => 'purgedefinition',
+                    'definition' => $definitionsummary['id'], 'sesskey' => sesskey()]),
                 get_string('purge', 'cache')
             );
         }
@@ -107,7 +106,7 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         if (!empty($CFG->tool_forcedcache_config_path)) {
             $path = $CFG->tool_forcedcache_config_path;
         } else {
-            $path = __DIR__.'/../config.json';
+            $path = __DIR__ . '/../config.json';
         }
         // We dont need safety here, if we reach this point,
         // Its already been included and working.
@@ -143,10 +142,10 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         $table = new html_table();
         $table->id = $name . '_def_table';
         $table->attributes['class'] = 'generaltable table table-bordered table-sm w-auto';
-        $table->head = array (
+        $table->head = [
             get_string('store_config', 'tool_forcedcache'),
             get_string('store_value', 'tool_forcedcache'),
-        );
+        ];
         $table->data = [];
         foreach ($config['config'] as $key => $value) {
             $table->data[] = [s($key), s($value)];
@@ -174,10 +173,10 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         $table = new html_table();
         $table->id = 'def_override_table';
         $table->attributes['class'] = 'generaltable table table-bordered table-sm w-auto';
-        $table->head = array (
+        $table->head = [
             get_string('definition_name', 'tool_forcedcache'),
             get_string('definition_overrides', 'tool_forcedcache'),
-        );
+        ];
         $table->data = [];
         foreach ($overrides as $definition => $items) {
             $itemstring = '';
@@ -222,11 +221,11 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         $table = new html_table();
         $table->id = $mode . '_rule_table';
         $table->attributes['class'] = 'generaltable table table-bordered table-sm w-auto';
-        $table->head = array (
+        $table->head = [
             get_string('rule_priority', 'tool_forcedcache'),
             get_string('rule_ruleset', 'tool_forcedcache'),
-            get_string('mappings', 'cache')
-        );
+            get_string('mappings', 'cache'),
+        ];
 
         $counter = 1;
         $defaultrulestr = get_string('rule_default_rule', 'tool_forcedcache');
@@ -242,11 +241,11 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
                 $conditions = $defaultrulestr;
             }
 
-            $table->data[] = array(
+            $table->data[] = [
                 $counter,
                 $conditions,
                 s(implode(',', $ruleset['stores'])),
-            );
+            ];
             $counter++;
         }
 
@@ -256,17 +255,17 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         if (empty($table->data) || end($table->data)[1] !== $defaultrulestr) {
             // Append a default entry to the table.
             $defaultmodemappings = tool_forcedcache_cache_config::get_default_mode_mappings();
-            $defaultstoreformode = array_filter($defaultmodemappings, function($modemapping) use ($mode) {
+            $defaultstoreformode = array_filter($defaultmodemappings, function ($modemapping) use ($mode) {
                 return $modemapping['mode'] === $mode;
             });
             $defaultstore = reset($defaultstoreformode)['store'];
             $conditions = $defaultrulestr;
 
-            $table->data[] = array(
+            $table->data[] = [
                 $counter,
                 $conditions,
                 implode(',', (array) $defaultstore),
-            );
+            ];
         }
 
         // Now output a header and the table.
@@ -276,7 +275,8 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         if (count($rules[$ruletype]) === 0) {
             $html .= $OUTPUT->notification(
                 get_string('rule_no_rulesets', 'tool_forcedcache', $defaultstore),
-                \core\output\notification::NOTIFY_WARNING);
+                \core\output\notification::NOTIFY_WARNING
+            );
             $html .= html_writer::table($table);
         } else {
             $html .= html_writer::table($table);

--- a/classes/cache_config.php
+++ b/classes/cache_config.php
@@ -25,7 +25,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_forcedcache_cache_config extends cache_config {
-
     /**
      * Array to track errors thrown during store instantiation.
      *
@@ -70,8 +69,10 @@ class tool_forcedcache_cache_config extends cache_config {
             }
 
             // If plugin is supposed to be active, rethrow exception, can't continue with broken config.
-            if (!empty($CFG->alternative_cache_factory_class)
-                && $CFG->alternative_cache_factory_class === 'tool_forcedcache_cache_factory') {
+            if (
+                !empty($CFG->alternative_cache_factory_class)
+                && $CFG->alternative_cache_factory_class === 'tool_forcedcache_cache_factory'
+            ) {
                 throw $e;
             }
         }
@@ -98,8 +99,10 @@ class tool_forcedcache_cache_config extends cache_config {
         $modemappings = $this->generate_mode_mapping($config['rules']);
 
         // Get the definitions.
-        $definitions = $this->apply_definition_overrides(tool_forcedcache_cache_config_writer::locate_definitions(),
-            $config['definitionoverrides']);
+        $definitions = $this->apply_definition_overrides(
+            tool_forcedcache_cache_config_writer::locate_definitions(),
+            $config['definitionoverrides']
+        );
 
         // Generate definition mappings from rulesets.
         $definitionmappings = $this->generate_definition_mappings_from_rules($config['rules'], $definitions);
@@ -118,7 +121,7 @@ class tool_forcedcache_cache_config extends cache_config {
             'modemappings' => $modemappings,
             'definitions' => $definitions,
             'definitionmappings' => $definitionmappings,
-            'locks' => $locks
+            'locks' => $locks,
         ];
 
         // Get the siteidentifier. Copies pattern from cache_config.
@@ -129,7 +132,6 @@ class tool_forcedcache_cache_config extends cache_config {
         }
 
         return $config;
-
     }
 
     /**
@@ -161,7 +163,6 @@ class tool_forcedcache_cache_config extends cache_config {
 
             // Return config array.
             return $array;
-
         } else if ($pathexists) {
             // Else decide on the path, then try to load it.
             $path = realpath($CFG->tool_forcedcache_config_path);
@@ -172,7 +173,7 @@ class tool_forcedcache_cache_config extends cache_config {
         if (!empty($path) && strpos($path, $CFG->dirroot) !== false) {
             throw new cache_exception(get_string('config_json_path_invalid', 'tool_forcedcache', [
                 'path' => $path,
-                'dirroot' => $CFG->dirroot
+                'dirroot' => $CFG->dirroot,
             ]));
         }
 
@@ -204,21 +205,22 @@ class tool_forcedcache_cache_config extends cache_config {
      * @throws cache_exception
      */
     private function generate_store_instance_config(array $stores): array {
-        $storesarr = array();
+        $storesarr = [];
         foreach ($stores as $name => $store) {
-
             // First check that all the required fields are present in the store.
-            if (!(array_key_exists('type', $store) &&
-                  array_key_exists('config', $store))) {
+            if (
+                !(array_key_exists('type', $store) &&
+                  array_key_exists('config', $store))
+            ) {
                 throw new cache_exception(get_string('store_missing_fields', 'tool_forcedcache', $name));
             }
 
-            $storearr = array();
+            $storearr = [];
             $storearr['name'] = $name;
             $storearr['plugin'] = $store['type'];
             // Assume all configuration is correct.
             $storearr['configuration'] = $store['config'];
-            $classname = 'cachestore_'.$store['type'];
+            $classname = 'cachestore_' . $store['type'];
             $storearr['class'] = $classname;
 
             // Now for the derived config from the store information provided.
@@ -233,7 +235,7 @@ class tool_forcedcache_cache_config extends cache_config {
                 !file_exists($cachepath)
             ) {
                 throw new cache_exception(
-                    get_string('store_bad_type','tool_forcedcache', $store['type'])
+                    get_string('store_bad_type', 'tool_forcedcache', $store['type'])
                 );
             }
             require_once($cachepath);
@@ -271,25 +273,25 @@ class tool_forcedcache_cache_config extends cache_config {
      *
      * @return array the generated default mode mappings.
      */
-    public static function get_default_mode_mappings() : array {
+    public static function get_default_mode_mappings(): array {
         // Use the defaults from core.
-        $modemappings = array(
-            array(
+        $modemappings = [
+            [
                 'mode' => cache_store::MODE_APPLICATION,
                 'store' => 'default_application',
-                'sort' => -1
-            ),
-            array(
+                'sort' => -1,
+            ],
+            [
                 'mode' => cache_store::MODE_SESSION,
                 'store' => 'default_session',
-                'sort' => -1
-            ),
-            array(
+                'sort' => -1,
+            ],
+            [
                 'mode' => cache_store::MODE_REQUEST,
                 'store' => 'default_request',
-                'sort' => -1
-            )
-        );
+                'sort' => -1,
+            ],
+        ];
 
         return $modemappings;
     }
@@ -337,7 +339,7 @@ class tool_forcedcache_cache_config extends cache_config {
      * @return array an array of ordered mappings for every definition to its ruleset.
      */
     private function generate_definition_mappings_from_rules(array $rules, array $definitions): array {
-        $defmappings = array();
+        $defmappings = [];
         $num = 1;
         foreach ($definitions as $defname => $definition) {
             // Find the mode of the definition to discover the mappings.
@@ -364,7 +366,7 @@ class tool_forcedcache_cache_config extends cache_config {
             }
 
             // Now decide on the ruleset that matches.
-            $stores = array();
+            $stores = [];
             foreach ($ruleset as $rule) {
                 if (array_key_exists('conditions', $rule)) {
                     foreach ($rule['conditions'] as $condition => $value) {
@@ -390,7 +392,7 @@ class tool_forcedcache_cache_config extends cache_config {
             $sort = count($stores);
             foreach ($stores as $store) {
                 // Create the mapping for the definition -> store and add to the master list.
-                $mappingarr = array();
+                $mappingarr = [];
                 $mappingarr['store'] = $store;
                 $mappingarr['definition'] = $defname;
                 $mappingarr['sort'] = $sort;
@@ -438,15 +440,15 @@ class tool_forcedcache_cache_config extends cache_config {
      *
      * @return array array of locks to use.
      */
-    private function generate_locks() : array {
-        return array(
-            'default_file_lock' => array(
+    private function generate_locks(): array {
+        return [
+            'default_file_lock' => [
                 'name' => 'cachelock_file_default',
                 'type' => 'cachelock_file',
                 'dir' => 'filelocks',
-                'default' => true
-            )
-        );
+                'default' => true,
+            ],
+        ];
     }
 
     /**

--- a/classes/cache_config_writer.php
+++ b/classes/cache_config_writer.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * This config_writer is readonly, and provides public access to some protected methods.
  *
@@ -25,7 +23,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_forcedcache_cache_config_writer extends cache_config_writer {
-
     /**
      * Overriding this means nothing gets Written.
      * This must still work if we fallback to core caching.

--- a/classes/cache_factory.php
+++ b/classes/cache_factory.php
@@ -53,14 +53,21 @@ class tool_forcedcache_cache_factory extends cache_factory {
             }
         }
 
+        $config = null;
+
         if (!array_key_exists($class, $this->configs)) {
             // Create a new instance and call it to load it.
             // As part of generating store instance config we test the initialisation of stores.
             // Testing this may initialise DI, which will attempt to use cache for hookcallbacks.
             // Setting the state to initialising will make it use ad-hoc cache for that request.
             self::set_state(self::STATE_INITIALISING);
-            $this->configs[$class] = new $class;
-            $this->configs[$class]->load();
+            $config = new $class();
+            $config->load();
+
+            // Re-register after load in case anything reset $this->configs.
+            $this->configs[$class] = $config;
+        } else {
+            $config = $this->configs[$class];
         }
 
         // We need the siteid in order to use the caches, but the siteid
@@ -77,7 +84,7 @@ class tool_forcedcache_cache_factory extends cache_factory {
         }
 
         // Return the instance.
-        return $this->configs[$class];
+        return $config;
     }
 
     /**

--- a/classes/cache_factory.php
+++ b/classes/cache_factory.php
@@ -23,7 +23,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_forcedcache_cache_factory extends cache_factory {
-
     /**
      * This is a copy of the core class, with the classes swapped out.
      * TODO: Refactor core method to accept class param, and call parent with param.
@@ -40,7 +39,7 @@ class tool_forcedcache_cache_factory extends cache_factory {
 
         // Check if this is a PHPUnit test and redirect to the phpunit config classes if it is.
         if ($testing) {
-            require_once($CFG->dirroot.'/cache/tests/fixtures/lib.php');
+            require_once($CFG->dirroot . '/cache/tests/fixtures/lib.php');
             // We have just a single class for PHP unit tests. We don't care enough about its
             // performance to do otherwise and having a single method allows us to inject things into it
             // while testing.
@@ -93,7 +92,7 @@ class tool_forcedcache_cache_factory extends cache_factory {
      *
      * @return core_cache\administration_helper
      */
-    public static function get_administration_display_helper() : core_cache\administration_helper {
+    public static function get_administration_display_helper(): core_cache\administration_helper {
         // Check if there was a config error.
         global $SESSION;
 

--- a/classes/check/enabled.php
+++ b/classes/check/enabled.php
@@ -51,7 +51,7 @@ class enabled extends check {
      *
      * @return result
      */
-    public function get_result() : result {
+    public function get_result(): result {
         global $CFG;
 
         // Create a dummy cache config instance and check for errors in instantiation.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -26,14 +26,13 @@ namespace tool_forcedcache\privacy;
 class provider implements
     // This plugin does not store any personal user data.
     \core_privacy\local\metadata\null_provider {
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@
  */
 
 require_once(__DIR__ . '/../../../config.php');
-require_once($CFG->libdir.'/adminlib.php');
+require_once($CFG->libdir . '/adminlib.php');
 
 admin_externalpage_setup('tool_forcedcache_status');
 
@@ -36,9 +36,11 @@ echo $OUTPUT->header();
 $dummy = new tool_forcedcache_cache_config();
 $errors = $dummy->get_inclusion_errors();
 
-if (empty($CFG->alternative_cache_factory_class) ||
+if (
+    empty($CFG->alternative_cache_factory_class) ||
     $CFG->alternative_cache_factory_class !== 'tool_forcedcache_cache_factory' ||
-    !empty($errors)) {
+    !empty($errors)
+) {
     echo $OUTPUT->notification(get_string('page_not_active', 'tool_forcedcache'), \core\output\notification::NOTIFY_ERROR);
 } else {
     echo $OUTPUT->notification(get_string('page_active', 'tool_forcedcache'), \core\output\notification::NOTIFY_SUCCESS);

--- a/lang/en/tool_forcedcache.php
+++ b/lang/en/tool_forcedcache.php
@@ -23,44 +23,34 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['pluginname'] = 'Forced Caching';
-
-// Page Strings.
-$string['page_status'] = 'Forced caching status';
-$string['page_config_ok'] = 'Forced cache config OK';
-$string['page_config_broken'] = 'Forced cache config broken';
-$string['page_config_broken_details'] = 'The reported error message is: {$a}';
-$string['page_mode'] = 'Mode: {$a}';
-$string['page_store'] = 'Store: {$a->name} ({$a->type})';
-$string['page_rulesets'] = 'Caching Rules';
-$string['page_not_active'] = 'Forced cache configuration is NOT active.';
-$string['page_active'] = 'Forced cache configuration IS active.';
-
-// Exception Strings.
-$string['config_json_parse_fail'] = 'Error parsing JSON to array. JSON syntax may be malformed.';
+$string['checkforcedcache'] = 'Check that forced caching is enabled.';
 $string['config_array_parse_fail'] = 'Error parsing configuration array. Array syntax may be malformed.';
 $string['config_json_missing'] = 'Error reading JSON file. File may not exist, path is incorrect or path has not been set.';
+$string['config_json_parse_fail'] = 'Error parsing JSON to array. JSON syntax may be malformed.';
 $string['config_json_path_invalid'] = 'Invalid configuration path. Please ensure the path {$a->path} is outside of the {$a->dirroot} directory.
 Please see https://github.com/catalyst/moodle-tool_forcedcache#set-a-path-to-the-json-configuration for further instructions.';
 $string['config_path_and_array'] = 'Detected both path to file and config array. Only one can be specified.';
-$string['definition_not_found'] = 'Definition not defined for configuration override: {$a}.';
-$string['store_missing_fields'] = 'Error reading store {$a}, it may be missing fields or malformed.';
-$string['store_bad_type'] = 'Error loading store {$a}. Store may not exist or type is malformed.';
-$string['store_not_ready'] = 'Error creating store {$a}, config may be incorrect or missing required fields.';
-
-
-// Table Strings.
-$string['definition_overrides_title'] = 'Definition overrides';
 $string['definition_name'] = 'Definition';
+$string['definition_not_found'] = 'Definition not defined for configuration override: {$a}.';
 $string['definition_overrides'] = 'Overrides';
+$string['definition_overrides_title'] = 'Definition overrides';
+$string['page_active'] = 'Forced cache configuration IS active.';
+$string['page_config_broken'] = 'Forced cache config broken';
+$string['page_config_broken_details'] = 'The reported error message is: {$a}';
+$string['page_config_ok'] = 'Forced cache config OK';
+$string['page_mode'] = 'Mode: {$a}';
+$string['page_not_active'] = 'Forced cache configuration is NOT active.';
+$string['page_rulesets'] = 'Caching Rules';
+$string['page_status'] = 'Forced caching status';
+$string['page_store'] = 'Store: {$a->name} ({$a->type})';
+$string['pluginname'] = 'Forced Caching';
+$string['privacy:metadata'] = 'The forced caching plugin does not store any data for any reason.';
 $string['rule_default_rule'] = 'Default rule';
 $string['rule_no_rulesets'] = 'No rulesets are defined for this mode. The default store for this mode is: {$a}.';
 $string['rule_priority'] = 'Priority';
 $string['rule_ruleset'] = 'Ruleset';
+$string['store_bad_type'] = 'Error loading store {$a}. Store may not exist or type is malformed.';
 $string['store_config'] = 'Name';
+$string['store_missing_fields'] = 'Error reading store {$a}, it may be missing fields or malformed.';
+$string['store_not_ready'] = 'Error creating store {$a}, config may be incorrect or missing required fields.';
 $string['store_value'] = 'Value';
-
-// Check Strings.
-$string['checkforcedcache'] = 'Check that forced caching is enabled.';
-
-$string['privacy:metadata'] = 'The forced caching plugin does not store any data for any reason.';

--- a/settings.php
+++ b/settings.php
@@ -26,10 +26,17 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
-    $ADMIN->add('tools', new admin_category('toolforcedcachefolder',
-        new lang_string('pluginname', 'tool_forcedcache'), false));
+    $ADMIN->add(
+        'tools',
+        new admin_category('toolforcedcachefolder', new lang_string('pluginname', 'tool_forcedcache'), false)
+    );
 
-    $ADMIN->add('toolforcedcachefolder', new admin_externalpage('tool_forcedcache_status',
-        get_string('page_status', 'tool_forcedcache'),
-        new moodle_url('/admin/tool/forcedcache/index.php')));
+    $ADMIN->add(
+        'toolforcedcachefolder',
+        new admin_externalpage(
+            'tool_forcedcache_status',
+            get_string('page_status', 'tool_forcedcache'),
+            new moodle_url('/admin/tool/forcedcache/index.php')
+        )
+    );
 }

--- a/tests/cache_config_test.php
+++ b/tests/cache_config_test.php
@@ -25,8 +25,7 @@ namespace tool_forcedcache;
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers      \tool_forcedcache_cache_config
  */
-class cache_config_test extends \advanced_testcase {
-
+final class cache_config_test extends \advanced_testcase {
     /**
      * Temporary directory for loading config into
      *
@@ -48,7 +47,7 @@ class cache_config_test extends \advanced_testcase {
         return realpath($dest);
     }
 
-    public function test_read_config_file_from_invalid_path() {
+    public function test_read_config_file_from_invalid_path(): void {
         global $CFG;
         $this->resetAfterTest(true);
 
@@ -68,12 +67,12 @@ class cache_config_test extends \advanced_testcase {
         $this->expectException(\cache_exception::class);
         $this->expectExceptionMessage(get_string('config_json_path_invalid', 'tool_forcedcache', [
             'path' => $CFG->tool_forcedcache_config_path,
-            'dirroot' => $CFG->dirroot
+            'dirroot' => $CFG->dirroot,
         ]));
         $method->invoke($config);
     }
 
-    public function test_read_valid_config_file() {
+    public function test_read_valid_config_file(): void {
         global $CFG;
         $this->resetAfterTest(true);
 
@@ -97,7 +96,7 @@ class cache_config_test extends \advanced_testcase {
         $this->assertArrayHasKey('definitionoverrides', $configarr1);
     }
 
-    public function test_read_garbled_config_file() {
+    public function test_read_garbled_config_file(): void {
         global $CFG;
         $this->resetAfterTest(true);
 
@@ -119,7 +118,7 @@ class cache_config_test extends \advanced_testcase {
         $method->invoke($config);
     }
 
-    public function test_read_non_existent_config_file() {
+    public function test_read_non_existent_config_file(): void {
         global $CFG;
         $this->resetAfterTest(true);
 
@@ -141,7 +140,7 @@ class cache_config_test extends \advanced_testcase {
         $method->invoke($config);
     }
 
-    public function test_generate_store_instance_config() {
+    public function test_generate_store_instance_config(): void {
         // Directly create a config.
         $config = new \tool_forcedcache_cache_config();
 
@@ -165,7 +164,7 @@ class cache_config_test extends \advanced_testcase {
         $this->assertEquals($storereqsnotmet['expected'], $method->invoke($config, $storereqsnotmet['input']));
     }
 
-    public function test_generate_store_instance_config_badtype() {
+    public function test_generate_store_instance_config_badtype(): void {
         // Directly create a config.
         $config = new \tool_forcedcache_cache_config();
 
@@ -183,7 +182,7 @@ class cache_config_test extends \advanced_testcase {
         $this->assertNull($storearr1);
     }
 
-    public function test_generate_store_instance_config_missingfield() {
+    public function test_generate_store_instance_config_missingfield(): void {
         // Directly create a config.
         $config = new \tool_forcedcache_cache_config();
 
@@ -204,7 +203,7 @@ class cache_config_test extends \advanced_testcase {
     /**
      * Test if default mappings return as expected.
      */
-    public function test_default_mode_mappings() {
+    public function test_default_mode_mappings(): void {
         $defaultmodemappings = \tool_forcedcache_cache_config::get_default_mode_mappings();
 
         // Read in the fixtures file for data.
@@ -216,7 +215,7 @@ class cache_config_test extends \advanced_testcase {
     /**
      * Tests output of mode mpapings once rules included in the mix.
      */
-    public function test_generated_mode_mappings_for_definitionmatchtopruleset() {
+    public function test_generated_mode_mappings_for_definitionmatchtopruleset(): void {
         $config = new \tool_forcedcache_cache_config();
         // Setup reflection for private function.
         $method = new \ReflectionMethod($config, 'generate_mode_mapping');
@@ -233,7 +232,7 @@ class cache_config_test extends \advanced_testcase {
     /**
      * Tests output of mode mpapings once rules included in the mix.
      */
-    public function test_generated_mode_mappings_for_definitionnoruleset() {
+    public function test_generated_mode_mappings_for_definitionnoruleset(): void {
         $config = new \tool_forcedcache_cache_config();
         // Setup reflection for private function.
         $method = new \ReflectionMethod($config, 'generate_mode_mapping');
@@ -247,7 +246,7 @@ class cache_config_test extends \advanced_testcase {
         $this->assertEquals($defaultsexpected, $method->invoke($config, $rules));
     }
 
-    public function test_generate_definition_mappings_from_rules() {
+    public function test_generate_definition_mappings_from_rules(): void {
         $config = new \tool_forcedcache_cache_config();
 
         // Setup reflection for private function.
@@ -258,19 +257,27 @@ class cache_config_test extends \advanced_testcase {
         include(__DIR__ . '/fixtures/definition_mappings_data.php');
 
         // Test when a condition and the name match.
-        $this->assertEquals($definitionmatchtopruleset['expected'],
-            $method->invoke($config, $definitionmatchtopruleset['rules'], $definitionmatchtopruleset['definition']));
+        $this->assertEquals(
+            $definitionmatchtopruleset['expected'],
+            $method->invoke($config, $definitionmatchtopruleset['rules'], $definitionmatchtopruleset['definition'])
+        );
 
         // Test when 1 condition fails in a set, fallthrough occurs.
-        $this->assertEquals($definitionnonmatchtopruleset['expected'],
-            $method->invoke($config, $definitionnonmatchtopruleset['rules'], $definitionnonmatchtopruleset['definition']));
+        $this->assertEquals(
+            $definitionnonmatchtopruleset['expected'],
+            $method->invoke($config, $definitionnonmatchtopruleset['rules'], $definitionnonmatchtopruleset['definition'])
+        );
 
         // Test when failing 2 rulesets, fall through to 3rd.
-        $this->assertEquals($definitionbottomruleset['expected'],
-            $method->invoke($config, $definitionbottomruleset['rules'], $definitionbottomruleset['definition']));
+        $this->assertEquals(
+            $definitionbottomruleset['expected'],
+            $method->invoke($config, $definitionbottomruleset['rules'], $definitionbottomruleset['definition'])
+        );
 
         // Test when all rulesets fail (no mappings).
-        $this->assertEquals($definitionnoruleset['expected'],
-            $method->invoke($config, $definitionnoruleset['rules'], $definitionnoruleset['definition']));
+        $this->assertEquals(
+            $definitionnoruleset['expected'],
+            $method->invoke($config, $definitionnoruleset['rules'], $definitionnoruleset['definition'])
+        );
     }
 }

--- a/tests/fixtures/definition_mappings_data.php
+++ b/tests/fixtures/definition_mappings_data.php
@@ -14,12 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Test fixture data for definition mappings.
+ *
+ * @package    tool_forcedcache
+ * @copyright  2020 Peter Burnett <peterburnett@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 defined('MOODLE_INTERNAL') || die();
 
-$definitionmatchtopruleset = array (
-    'definition' => array (
+$definitionmatchtopruleset = [
+    'definition' => [
         'core/string' =>
-        array (
+         [
         'mode' => 1,
         'simplekeys' => true,
         'simpledata' => true,
@@ -31,49 +39,49 @@ $definitionmatchtopruleset = array (
         'selectedsharingoption' => 2,
         'userinputsharingkey' => '',
         'sharingoptions' => 15,
-        ),
-    ),
-    'rules' => array (
-        'application' => array (
-            array (
-                'conditions' => array (
+        ],
+    ],
+    'rules' => [
+        'application' => [
+             [
+                'conditions' => [
                     'canuselocalstore' => true,
-                    'name' => 'core/string'
-                ),
-                'stores' => array(
+                    'name' => 'core/string',
+                ],
+                'stores' => [
                     'apcu-test',
-                    'file-test'
-                )
-            ),
-            array (
-                'stores' => array (
-                    'file-test'
-                )
-            )
-        ),
-        'session' => array(),
-        'request' => array()
-    ),
-    'expected' => array (
+                    'file-test',
+                ],
+             ],
+              [
+                'stores' => [
+                    'file-test',
+                ],
+             ],
+        ],
+        'session' => [],
+        'request' => [],
+    ],
+    'expected' => [
         1 =>
-        array (
+         [
           'store' => 'apcu-test',
           'definition' => 'core/string',
           'sort' => 2,
-        ),
+        ],
         2 =>
-        array (
+         [
           'store' => 'file-test',
           'definition' => 'core/string',
           'sort' => 1,
-        )
-    )
-);
+        ],
+    ],
+];
 
-$definitionnonmatchtopruleset = array (
-    'definition' => array (
+$definitionnonmatchtopruleset = [
+    'definition' => [
         'core/string' =>
-        array (
+         [
         'mode' => 1,
         'simplekeys' => true,
         'simpledata' => true,
@@ -85,43 +93,43 @@ $definitionnonmatchtopruleset = array (
         'selectedsharingoption' => 2,
         'userinputsharingkey' => '',
         'sharingoptions' => 15,
-        ),
-    ),
-    'rules' => array (
-        'application' => array (
-            array (
-                'conditions' => array (
+        ],
+    ],
+    'rules' => [
+        'application' => [
+             [
+                'conditions' => [
                     'canuselocalstore' => true,
-                    'name' => 'core/fakename'
-                ),
-                'stores' => array(
+                    'name' => 'core/fakename',
+                ],
+                'stores' => [
                     'apcu-test',
-                    'file-test'
-                )
-            ),
-            array (
-                'stores' => array (
-                    'file-test'
-                )
-            )
-        ),
-        'session' => array(),
-        'request' => array()
-    ),
-    'expected' => array (
+                    'file-test',
+                ],
+             ],
+              [
+                'stores' => [
+                    'file-test',
+                ],
+             ],
+        ],
+        'session' => [],
+        'request' => [],
+    ],
+    'expected' => [
         1 =>
-        array (
+         [
           'store' => 'file-test',
           'definition' => 'core/string',
           'sort' => 1,
-        )
-    )
-);
+        ],
+    ],
+];
 
-$definitionbottomruleset = array (
-    'definition' => array (
+$definitionbottomruleset = [
+    'definition' => [
         'core/string' =>
-        array (
+         [
         'mode' => 1,
         'simplekeys' => true,
         'simpledata' => true,
@@ -133,53 +141,53 @@ $definitionbottomruleset = array (
         'selectedsharingoption' => 2,
         'userinputsharingkey' => '',
         'sharingoptions' => 15,
-        ),
-    ),
-    'rules' => array (
-        'application' => array (
-            array (
-                'conditions' => array (
+        ],
+    ],
+    'rules' => [
+        'application' => [
+             [
+                'conditions' => [
                     'canuselocalstore' => true,
-                    'name' => 'core/fakename'
-                ),
-                'stores' => array(
+                    'name' => 'core/fakename',
+                ],
+                'stores' => [
                     'apcu-test',
-                    'file-test'
-                )
-            ),
-            array (
-                'conditions' => array (
+                    'file-test',
+                ],
+             ],
+             [
+                'conditions' => [
                     'canuselocalstore' => false,
-                    'name' => 'core/fakename'
-                ),
-                'stores' => array(
+                    'name' => 'core/fakename',
+                ],
+                'stores' => [
                     'apcu-test',
-                    'file-test'
-                )
-            ),
-            array (
-                'stores' => array (
-                    'redis-test'
-                )
-            )
-        ),
-        'session' => array(),
-        'request' => array()
-    ),
-    'expected' => array (
+                    'file-test',
+                ],
+             ],
+              [
+                'stores' => [
+                    'redis-test',
+                ],
+             ],
+        ],
+        'session' => [],
+        'request' => [],
+    ],
+    'expected' => [
         1 =>
-        array (
+         [
           'store' => 'redis-test',
           'definition' => 'core/string',
           'sort' => 1,
-        )
-    )
-);
+        ],
+    ],
+];
 
-$definitionnoruleset = array (
-    'definition' => array (
+$definitionnoruleset = [
+    'definition' => [
         'core/string' =>
-        array (
+         [
         'mode' => 1,
         'simplekeys' => true,
         'simpledata' => true,
@@ -191,43 +199,43 @@ $definitionnoruleset = array (
         'selectedsharingoption' => 2,
         'userinputsharingkey' => '',
         'sharingoptions' => 15,
-        ),
-    ),
-    'rules' => array (
-        'application' => array (
-            array (
-                'conditions' => array (
+        ],
+    ],
+    'rules' => [
+        'application' => [
+             [
+                'conditions' => [
                     'canuselocalstore' => true,
-                    'name' => 'core/fakename'
-                ),
-                'stores' => array(
+                    'name' => 'core/fakename',
+                ],
+                'stores' => [
                     'apcu-test',
-                    'file-test'
-                )
-            ),
-            array (
-                'conditions' => array (
+                    'file-test',
+                ],
+             ],
+             [
+                'conditions' => [
                     'canuselocalstore' => false,
-                    'name' => 'core/fakename'
-                ),
-                'stores' => array(
+                    'name' => 'core/fakename',
+                ],
+                'stores' => [
                     'apcu-test',
-                    'file-test'
-                )
-            ),
-            array (
-                'conditions' => array (
+                    'file-test',
+                ],
+             ],
+              [
+                'conditions' => [
                     'canuselocalstore' => false,
-                    'name' => 'core/differentfakename'
-                ),
-                'stores' => array (
-                    'redis-test'
-                )
-            )
-        ),
-        'session' => array(),
-        'request' => array()
-    ),
-    'expected' => array (
-    )
-);
+                    'name' => 'core/differentfakename',
+                ],
+                'stores' => [
+                    'redis-test',
+                ],
+             ],
+        ],
+        'session' => [],
+        'request' => [],
+    ],
+    'expected' => [
+    ],
+];

--- a/tests/fixtures/mode_mappings_data.php
+++ b/tests/fixtures/mode_mappings_data.php
@@ -14,40 +14,48 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Test fixture data for mode mappings.
+ *
+ * @package    tool_forcedcache
+ * @copyright  2020 Peter Burnett <peterburnett@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 defined('MOODLE_INTERNAL') || die();
 
-$defaultsexpected = array(
-    array(
+$defaultsexpected = [
+    [
         'mode' => cache_store::MODE_APPLICATION,
         'store' => 'default_application',
-        'sort' => -1
-    ),
-    array(
+        'sort' => -1,
+    ],
+    [
         'mode' => cache_store::MODE_SESSION,
         'store' => 'default_session',
-        'sort' => -1
-    ),
-    array(
+        'sort' => -1,
+    ],
+    [
         'mode' => cache_store::MODE_REQUEST,
         'store' => 'default_request',
-        'sort' => -1
-    )
-);
+        'sort' => -1,
+    ],
+];
 
-$generatedmodemappingagainstdefinitionmatchtoprulesetexpected = array(
-    array(
+$generatedmodemappingagainstdefinitionmatchtoprulesetexpected = [
+    [
         'mode' => cache_store::MODE_APPLICATION,
         'store' => 'file-test',
-        'sort' => -1
-    ),
-    array(
+        'sort' => -1,
+    ],
+    [
         'mode' => cache_store::MODE_SESSION,
         'store' => 'default_session',
-        'sort' => -1
-    ),
-    array(
+        'sort' => -1,
+    ],
+    [
         'mode' => cache_store::MODE_REQUEST,
         'store' => 'default_request',
-        'sort' => -1
-    )
-);
+        'sort' => -1,
+    ],
+];

--- a/tests/fixtures/stores_data.php
+++ b/tests/fixtures/stores_data.php
@@ -14,282 +14,290 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Test fixture data for cache stores.
+ *
+ * @package    tool_forcedcache
+ * @copyright  2020 Peter Burnett <peterburnett@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 defined('MOODLE_INTERNAL') || die();
 
-$storeone = array (
-    'input' => array (
-        'filetest' => array (
+$storeone = [
+    'input' => [
+        'filetest' => [
             'type' => 'file',
-            'config' => array (
+            'config' => [
                 'path' => '/tmp/hardcode',
-                'autocreate' => 1
-            )
-        )
-    ),
-    'expected' => array (
+                'autocreate' => 1,
+            ],
+        ],
+    ],
+    'expected' => [
         'filetest' =>
-            array (
+             [
                 'name' => 'filetest',
                 'plugin' => 'file',
                 'configuration' =>
-                    array (
+                     [
                         'path' => '/tmp/hardcode',
                         'autocreate' => 1,
-                    ),
+                    ],
                 'features' => 30,
                 'modes' => 3,
                 'mappingsonly' => false,
                 'class' => 'cachestore_file',
                 'default' => false,
                 'lock' => 'cachelock_file_default',
-                ),
+                ],
         'default_application' =>
-            array (
+             [
                 'name' => 'default_application',
                 'plugin' => 'file',
                 'configuration' =>
-                    array (
-                    ),
+                     [
+                    ],
                 'features' => 30,
                 'modes' => 3,
                 'default' => true,
                 'class' => 'cachestore_file',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_session' =>
-            array (
+             [
                 'name' => 'default_session',
                 'plugin' => 'session',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 14,
                 'modes' => 2,
                 'default' => true,
                 'class' => 'cachestore_session',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_request' =>
-            array (
+             [
                 'name' => 'default_request',
                 'plugin' => 'static',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 31,
                 'modes' => 4,
                 'default' => true,
                 'class' => 'cachestore_static',
                 'lock' => 'cachelock_file_default',
-            )
-    )
-);
+            ],
+    ],
+];
 
-$storetwo = array (
-    'input' => array (
-        'filetest' => array (
+$storetwo = [
+    'input' => [
+        'filetest' => [
             'type' => 'file',
-            'config' => array (
+            'config' => [
                 'path' => '/tmp/hardcode',
-                'autocreate' => 1
-            )
-        ),
-        'filetest2' => array (
+                'autocreate' => 1,
+            ],
+        ],
+        'filetest2' => [
             'type' => 'file',
-            'config' => array (
+            'config' => [
                 'path' => '/tmp/hardcode2',
-                'autocreate' => 1
-            )
-        )
-    ),
-    'expected' => array (
+                'autocreate' => 1,
+            ],
+        ],
+    ],
+    'expected' => [
         'filetest' =>
-            array (
+             [
                 'name' => 'filetest',
                 'plugin' => 'file',
                 'configuration' =>
-                    array (
+                     [
                         'path' => '/tmp/hardcode',
                         'autocreate' => 1,
-                    ),
+                    ],
                 'features' => 30,
                 'modes' => 3,
                 'mappingsonly' => false,
                 'class' => 'cachestore_file',
                 'default' => false,
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'filetest2' =>
-            array (
+             [
                 'name' => 'filetest2',
                 'plugin' => 'file',
                 'configuration' =>
-                    array (
+                     [
                         'path' => '/tmp/hardcode2',
                         'autocreate' => 1,
-                    ),
+                    ],
                 'features' => 30,
                 'modes' => 3,
                 'mappingsonly' => false,
                 'class' => 'cachestore_file',
                 'default' => false,
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_application' =>
-            array (
+             [
                 'name' => 'default_application',
                 'plugin' => 'file',
                 'configuration' =>
-                    array (
-                    ),
+                     [
+                    ],
                 'features' => 30,
                 'modes' => 3,
                 'default' => true,
                 'class' => 'cachestore_file',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_session' =>
-            array (
+             [
                 'name' => 'default_session',
                 'plugin' => 'session',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 14,
                 'modes' => 2,
                 'default' => true,
                 'class' => 'cachestore_session',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_request' =>
-            array (
+             [
                 'name' => 'default_request',
                 'plugin' => 'static',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 31,
                 'modes' => 4,
                 'default' => true,
                 'class' => 'cachestore_static',
                 'lock' => 'cachelock_file_default',
-            )
-    )
-);
+            ],
+    ],
+];
 
-$storezero = array (
-    'input' => array (
-    ),
-    'expected' => array (
+$storezero = [
+    'input' => [
+    ],
+    'expected' => [
         'default_application' =>
-            array (
+             [
                 'name' => 'default_application',
                 'plugin' => 'file',
                 'configuration' =>
-                    array (
-                    ),
+                     [
+                    ],
                 'features' => 30,
                 'modes' => 3,
                 'default' => true,
                 'class' => 'cachestore_file',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_session' =>
-            array (
+             [
                 'name' => 'default_session',
                 'plugin' => 'session',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 14,
                 'modes' => 2,
                 'default' => true,
                 'class' => 'cachestore_session',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_request' =>
-            array (
+             [
                 'name' => 'default_request',
                 'plugin' => 'static',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 31,
                 'modes' => 4,
                 'default' => true,
                 'class' => 'cachestore_static',
                 'lock' => 'cachelock_file_default',
-            )
-    )
-);
+            ],
+    ],
+];
 
-$storebadtype = array (
-    'input' => array (
-        'apcutest' => array (
+$storebadtype = [
+    'input' => [
+        'apcutest' => [
             'type' => 'faketype',
-            'config' => array (
-                'prefix' => 'test'
-            )
-        )
-    )
-);
+            'config' => [
+                'prefix' => 'test',
+            ],
+        ],
+    ],
+];
 
-$storemissingfield = array (
-    'input' => array (
-        'apcutest' => array (
+$storemissingfield = [
+    'input' => [
+        'apcutest' => [
             'type' => 'faketype',
-        )
-    )
-);
+        ],
+    ],
+];
 
-$storereqsnotmet = array (
-    'input' => array (
-        'apcutest' => array (
+$storereqsnotmet = [
+    'input' => [
+        'apcutest' => [
             'type' => 'apcu',
-            'config' => array (
+            'config' => [
                 'prefix' => 'test_',
-            )
-        )
-    ),
-    'expected' => array (
+            ],
+        ],
+    ],
+    'expected' => [
         'default_application' =>
-            array (
+             [
                 'name' => 'default_application',
                 'plugin' => 'file',
                 'configuration' =>
-                    array (
-                    ),
+                     [
+                    ],
                 'features' => 30,
                 'modes' => 3,
                 'default' => true,
                 'class' => 'cachestore_file',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_session' =>
-            array (
+             [
                 'name' => 'default_session',
                 'plugin' => 'session',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 14,
                 'modes' => 2,
                 'default' => true,
                 'class' => 'cachestore_session',
                 'lock' => 'cachelock_file_default',
-            ),
+            ],
         'default_request' =>
-            array (
+             [
                 'name' => 'default_request',
                 'plugin' => 'static',
                 'configuration' =>
-                array (
-                ),
+                 [
+                ],
                 'features' => 31,
                 'modes' => 4,
                 'default' => true,
                 'class' => 'cachestore_static',
                 'lock' => 'cachelock_file_default',
-            )
-    )
-);
+            ],
+    ],
+];

--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024093001;
-$plugin->release   = "2024093000";
+$plugin->version   = 2024093002;
+$plugin->release   = "2024093002";
 $plugin->requires  = 2024092700; // Requires 4.5.
 $plugin->component = 'tool_forcedcache'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
-$plugin->supported = [405, 405];
+$plugin->supported = [405, 500];
 $plugin->incompatible = 501;


### PR DESCRIPTION
Fixes #81 
## Changes

### classes/cache_factory.php
- Store config instance in a local `$config` variable before calling `load()`
- Assign to `$this->configs[$class]` after load completes (survives `factory::reset()`)
- Return `$config` directly instead of `$this->configs[$class]`

### version.php
- Bump version to `2024093002`
- Change `$plugin->supported` from `[405, 405]` to `[405, 500]`
- Keep `$plugin->incompatible = 501` (still incompatible with 5.1+)

## Testing

1. Configure `$CFG->alternative_cache_factory_class = 'tool_forcedcache_cache_factory'`
2. Run `php admin/cli/check_database_schema.php`
3. Verify no cache factory exception

## Origin

Fix backported from MOODLE_501_STABLE branch (commit pattern from upstream).